### PR TITLE
Add the ability to use a custom transport in the Mnubo client

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,10 @@ root@4d7a461e5fbc:/workspaces/smartobjects-go-client# cd mnubo/
 root@4d7a461e5fbc:/workspaces/smartobjects-go-client# /usr/local/go/bin/go test -timeout 30s
 ```
 
+## Multithreading Warning
+
+This library is not optimized or tested for multi threaded usage. The client is *NOT* fully thread safe.
+
 ## References
 
 [mnubo documentation](https://smartobjects.mnubo.com/documentation/)

--- a/mnubo/client.go
+++ b/mnubo/client.go
@@ -54,6 +54,7 @@ type Mnubo struct {
 	Objects            *Objects
 	Owners             *Owners
 	Search             *Search
+	CustomTransport    *http.Transport
 }
 
 // ClientRequest is an internal structure to help with making HTTP requests to SmartObjects.
@@ -117,11 +118,11 @@ func NewClientWithToken(token string, host string) *Mnubo {
 
 // initClient initializes internal wrappers for SmartObjects main endpoints.
 func (m *Mnubo) initClient() {
-	m.Model = NewModel(*m)
-	m.Events = NewEvents(*m)
-	m.Objects = NewObjects(*m)
-	m.Owners = NewOwners(*m)
-	m.Search = NewSearch(*m)
+	m.Model = NewModel(m)
+	m.Events = NewEvents(m)
+	m.Objects = NewObjects(m)
+	m.Owners = NewOwners(m)
+	m.Search = NewSearch(m)
 	m.Timeout = DefaultTimeout
 	m.ExponentialBackoff = ExponentialBackoffConfig{
 		MaxElapsedTime: DefaultBackoffMaxInterval,
@@ -292,6 +293,9 @@ func (m *Mnubo) doRequest(cr ClientRequest, response interface{}) error {
 
 	client := &http.Client{
 		Timeout: m.Timeout,
+	}
+	if m.CustomTransport != nil {
+		client.Transport = m.CustomTransport
 	}
 
 	b := backoff.NewExponentialBackOff()

--- a/mnubo/client_test.go
+++ b/mnubo/client_test.go
@@ -91,7 +91,23 @@ func TestCompression(t *testing.T) {
 	}
 }
 
+func TestClientCustomTransport(t *testing.T) {
+	m := NewClient(os.Getenv("MNUBO_CLIENT_ID"), os.Getenv("MNUBO_CLIENT_SECRET"), os.Getenv("MNUBO_HOST"))
+
+	// setting a custom transport with impossibly small timeout
+	customTransport := &http.Transport{
+		TLSHandshakeTimeout: time.Nanosecond,
+	}
+	m.CustomTransport = customTransport
+
+	_, err := m.GetAccessToken()
+	if err == nil {
+		t.Errorf("able to get access token, despite faulty custom transport: %s", err)
+	}
+}
+
 func TestExponentialBackoff(t *testing.T) {
+	m := NewClient(os.Getenv("MNUBO_CLIENT_ID"), os.Getenv("MNUBO_CLIENT_SECRET"), os.Getenv("MNUBO_HOST"))
 	simFailures := 4
 	var sendError = simFailures
 	var gotNotified = 0
@@ -125,6 +141,7 @@ func TestExponentialBackoff(t *testing.T) {
 }
 
 func TestClientErrors(t *testing.T) {
+	m := NewClient(os.Getenv("MNUBO_CLIENT_ID"), os.Getenv("MNUBO_CLIENT_SECRET"), os.Getenv("MNUBO_HOST"))
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "This is an error returned by the platform.", http.StatusBadRequest)
 	}))

--- a/mnubo/ingestion.go
+++ b/mnubo/ingestion.go
@@ -14,22 +14,22 @@ const (
 
 // Events is a helper to Mnubo client which contains Events related functions.
 type Events struct {
-	Mnubo Mnubo
+	Mnubo *Mnubo
 }
 
 // Objects is a helper to Mnubo client which contains Objects related functions.
 type Objects struct {
-	Mnubo Mnubo
+	Mnubo *Mnubo
 }
 
 // Owners is a helper to Mnubo client which contains Owners related functions.
 type Owners struct {
-	Mnubo Mnubo
+	Mnubo *Mnubo
 }
 
 // Search is a helper to Mnubo client which contains Search related functions.
 type Search struct {
-	Mnubo Mnubo
+	Mnubo *Mnubo
 }
 
 // SendEventsOptions helps configure the Send events function.
@@ -67,21 +67,21 @@ type PasswordUpdatePayload struct {
 }
 
 // NewEvents creates an Events wrapper for Mnubo client.
-func NewEvents(m Mnubo) *Events {
+func NewEvents(m *Mnubo) *Events {
 	return &Events{
 		Mnubo: m,
 	}
 }
 
 // NewObjects creates an Objects wrapper for Mnubo client.
-func NewObjects(m Mnubo) *Objects {
+func NewObjects(m *Mnubo) *Objects {
 	return &Objects{
 		Mnubo: m,
 	}
 }
 
 // NewOwners creates an Owners wrapper for Mnubo client.
-func NewOwners(m Mnubo) *Owners {
+func NewOwners(m *Mnubo) *Owners {
 	return &Owners{
 		Mnubo: m,
 	}

--- a/mnubo/modeler.go
+++ b/mnubo/modeler.go
@@ -11,7 +11,7 @@ const (
 
 // Model is a helper to Mnubo client which contains Model related functions.
 type Model struct {
-	Mnubo Mnubo
+	Mnubo *Mnubo
 }
 
 type AttributeType struct {
@@ -87,7 +87,7 @@ type DataModel struct {
 	ReservedEnrichersFields []string            `json:"reservedEnrichersFields,omitempty"`
 }
 
-func NewModel(m Mnubo) *Model {
+func NewModel(m *Mnubo) *Model {
 	return &Model{
 		Mnubo: m,
 	}

--- a/mnubo/search.go
+++ b/mnubo/search.go
@@ -44,7 +44,7 @@ type SearchResults struct {
 }
 
 // NewSearch creates a Search wrapper for Mnubo client.
-func NewSearch(m Mnubo) *Search {
+func NewSearch(m *Mnubo) *Search {
 	return &Search{
 		Mnubo: m,
 	}


### PR DESCRIPTION
Mnubo client now has a property called "CustomTransport". When this is set, the defined transport will be used for all http requests made by the client.